### PR TITLE
Fix get_menu_json.py

### DIFF
--- a/geonode_mapstore_client/templatetags/get_menu_json.py
+++ b/geonode_mapstore_client/templatetags/get_menu_json.py
@@ -55,14 +55,13 @@ def get_base_left_topbar_menu(context):
             "type": "link",
             "href": "/catalogue/#/search/?f=document",
             "label": "Documents",
-        }
+        },
         {
             "type": "link",
             "href": "/catalogue/#/search/?f=featured",
             "label": "Featured",
         },
     ]
-
 
 @register.simple_tag(takes_context=True)
 def get_base_right_topbar_menu(context):


### PR DESCRIPTION
Fixes 

2024-02-21 16:12:22   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
2024-02-21 16:12:22   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
2024-02-21 16:12:22   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
2024-02-21 16:12:22   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
2024-02-21 16:12:22   File "<frozen importlib._bootstrap_external>", line 879, in exec_module
2024-02-21 16:12:22   File "<frozen importlib._bootstrap_external>", line 1017, in get_code
2024-02-21 16:12:22   File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
2024-02-21 16:12:22   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
2024-02-21 16:12:22   File "/usr/src/django-geonode-mapstore-client/geonode_mapstore_client/templatetags/get_menu_json.py", line 54